### PR TITLE
Show placeholder image when recipe has no image

### DIFF
--- a/src/RecipeCard.tsx
+++ b/src/RecipeCard.tsx
@@ -16,7 +16,12 @@ function RecipeCard({ recipe }: RecipeCardProps) {
       className="RecipeCard flex flex-col h-full min-w-37.5 rounded border border-border bg-white overflow-hidden"
       to={`/recipes/${recipe.id}`}
     >
-        <img src={recipe.image_url || PLACEHOLDER_IMAGE} className="w-full" alt={recipe.name} />
+        <img
+          src={recipe.image_url || PLACEHOLDER_IMAGE}
+          onError={(e) => { e.currentTarget.src = PLACEHOLDER_IMAGE; }}
+          className="w-full"
+          alt={recipe.name}
+        />
         <div className="flex-1 p-4">
           <h5 className="text-2xl font-medium mb-3">{recipe.name}</h5>
           <p className="text-xs text-muted uppercase font-normal">{recipe.hashtag}</p>

--- a/src/RecipeCard.tsx
+++ b/src/RecipeCard.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import "./RecipeCard.css";
 import { Link } from "react-router-dom";
 import { RecipeListItem } from "./types";
+import { PLACEHOLDER_IMAGE } from "./placeholder";
 
 interface RecipeCardProps {
   recipe: RecipeListItem;
@@ -15,7 +16,7 @@ function RecipeCard({ recipe }: RecipeCardProps) {
       className="RecipeCard flex flex-col h-full min-w-37.5 rounded border border-border bg-white overflow-hidden"
       to={`/recipes/${recipe.id}`}
     >
-        <img src={recipe.image_url} className="w-full" alt={recipe.name} />
+        <img src={recipe.image_url || PLACEHOLDER_IMAGE} className="w-full" alt={recipe.name} />
         <div className="flex-1 p-4">
           <h5 className="text-2xl font-medium mb-3">{recipe.name}</h5>
           <p className="text-xs text-muted uppercase font-normal">{recipe.hashtag}</p>

--- a/src/RecipeDetails.tsx
+++ b/src/RecipeDetails.tsx
@@ -4,6 +4,7 @@ import { supabase } from "./supabaseClient";
 import { Recipe } from "./types";
 import RecipeInstructions from "./RecipeInstructions";
 import NavBar from "./NavBar";
+import { PLACEHOLDER_IMAGE } from "./placeholder";
 
 function RecipeDetails() {
   const { recipeId } = useParams();
@@ -65,13 +66,11 @@ function RecipeDetails() {
 
       <div className="wireframe max-w-5xl 2xl:max-w-7xl mx-auto">
         <div className="grid grid-cols-1 md:grid-cols-[1fr_2fr]">
-          {recipe.image_url && (
-            <img
-              src={recipe.image_url}
-              alt={recipe.name}
-              className="w-full h-full object-cover"
-            />
-          )}
+          <img
+            src={recipe.image_url || PLACEHOLDER_IMAGE}
+            alt={recipe.name}
+            className="w-full h-full object-cover"
+          />
           <div className="py-6 md:px-8">
             <h1 className="text-3xl font-bold mb-1">{recipe.name}</h1>
             <p className="text-muted text-sm uppercase mb-6">

--- a/src/RecipeDetails.tsx
+++ b/src/RecipeDetails.tsx
@@ -68,6 +68,7 @@ function RecipeDetails() {
         <div className="grid grid-cols-1 md:grid-cols-[1fr_2fr]">
           <img
             src={recipe.image_url || PLACEHOLDER_IMAGE}
+            onError={(e) => { e.currentTarget.src = PLACEHOLDER_IMAGE; }}
             alt={recipe.name}
             className="w-full h-full object-cover"
           />

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -1,12 +1,13 @@
 // Inline SVG data URI — no external file needed
+// Colors from the project theme (index.css)
 export const PLACEHOLDER_IMAGE =
   "data:image/svg+xml," +
   encodeURIComponent(
     `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
-      <rect fill="#e5e7eb" width="400" height="300"/>
+      <rect fill="#f6f6f6" width="400" height="300"/>
       <text x="50%" y="45%" dominant-baseline="middle" text-anchor="middle"
-            font-family="sans-serif" font-size="48" fill="#9ca3af">🍽</text>
+            font-family="sans-serif" font-size="48" fill="#909090">🍽</text>
       <text x="50%" y="60%" dominant-baseline="middle" text-anchor="middle"
-            font-family="sans-serif" font-size="14" fill="#9ca3af">No image</text>
+            font-family="sans-serif" font-size="14" fill="#909090">No image</text>
     </svg>`
   );

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -1,0 +1,12 @@
+// Inline SVG data URI — no external file needed
+export const PLACEHOLDER_IMAGE =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+      <rect fill="#e5e7eb" width="400" height="300"/>
+      <text x="50%" y="45%" dominant-baseline="middle" text-anchor="middle"
+            font-family="sans-serif" font-size="48" fill="#9ca3af">🍽</text>
+      <text x="50%" y="60%" dominant-baseline="middle" text-anchor="middle"
+            font-family="sans-serif" font-size="14" fill="#9ca3af">No image</text>
+    </svg>`
+  );


### PR DESCRIPTION
## Summary
- Adds an inline SVG placeholder image (plate icon + "No image" text) shown when `image_url` is empty
- Applied as fallback in both RecipeCard and RecipeDetails
- Image remains a required field in the Add Recipe form — the placeholder is a safety net for edge cases (failed uploads, direct DB edits, data imports)

Closes #20

## Test plan
- [x] Clear `image_url` on a recipe in Supabase → placeholder appears on card and detail page
- [x] Restore the URL → real image appears again
- [x] Add Recipe form still requires an image