### PR TITLE
Add product vision and refresh CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,73 +1,103 @@
 # Recipe App — CLAUDE.md
 
+## Product Vision
+
+See [VISION.md](VISION.md) for target users, the core problem (decision fatigue), design principles, anti-goals, and later-scope features. **All product decisions should flow from it.**
+
 ## Project Overview
 
-A React recipe browsing app with client-side routing. Users can browse recipe cards and view individual recipe detail pages. Built with Vite.
+A React + TypeScript recipe app backed by Supabase. Users can browse a grid of recipes, open a detail page, add new recipes (with image upload), and delete them. Data lives in Supabase (`recipes` table + `recipe-images` storage bucket).
 
 ## Tech Stack
 
 | Layer | Technology |
 |-------|-----------|
 | UI Framework | React 18 |
+| Language | TypeScript 5 (strict mode) |
 | Routing | React Router DOM 6 |
-| Styling | Bootstrap 5 + component-scoped CSS |
-| Build Tool | Vite 6 + @vitejs/plugin-react |
-| Icons | Font Awesome 5.x |
-| Font | Google Fonts — Montserrat (300, 400) |
+| Styling | Tailwind CSS v4 (via `@tailwindcss/vite`) + a few component-scoped CSS files |
+| Build Tool | Vite 6 + `@vitejs/plugin-react` |
+| Backend | Supabase (Postgres + Storage) |
+| Linting / Formatting | ESLint 9 (flat config) + Prettier |
 
 ## How to Run
 
 ```bash
-npm install      # Install dependencies (first time only)
-npm run dev      # Dev server at http://localhost:5173
-npm run build    # Production build → /dist
-npm run preview  # Serve production build locally
+npm install        # Install dependencies (first time only)
+npm run dev        # Dev server at http://localhost:5173
+npm run build      # Production build → /dist
+npm run preview    # Serve production build locally
+npm run typecheck  # tsc --noEmit
+npm run lint       # ESLint over src
+npm run format     # Prettier write over src
 ```
+
+Supabase credentials are read from env vars: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`.
 
 ## Project Structure
 
 ```
 recipe-app/
-├── index.html              # Vite entry point (root-level)
-├── vite.config.js          # Vite + React plugin config
+├── index.html              # Vite entry point (root-level, NOT in /public)
+├── vite.config.mjs         # Vite + React + Tailwind plugin config (.mjs required for ESM)
+├── tsconfig.json           # TS strict config; excludes test files
 ├── public/
 │   └── manifest.json       # PWA manifest
 ├── src/
-│   ├── index.jsx           # React 18 createRoot entry
-│   ├── App.jsx             # Router setup; routes: / and /recipes/:recipeId
-│   ├── Search.jsx          # Search form (UI only, no functionality yet)
-│   ├── Recipes.jsx         # Recipe grid — maps recipeData → RecipeCard
-│   ├── RecipeCard.jsx      # Card with image, name, hashtag, like button
-│   ├── RecipeDetails.jsx   # Detail page; reads :recipeId via useParams
-│   ├── RecipeInstructions.jsx # Layout for ingredients/instructions (placeholder)
-│   ├── recipeData.js       # Hardcoded array of 4 recipe objects
-│   ├── images/             # 4 recipe JPGs imported in recipeData.js
-│   └── *.css               # Component-scoped CSS files
+│   ├── index.tsx           # React 18 createRoot entry (only file that imports React)
+│   ├── App.tsx             # Router v6 — routes: /, /recipes/new, /recipes/:recipeId
+│   ├── Recipes.tsx         # Recipe grid — fetches from Supabase
+│   ├── RecipeCard.tsx      # Card (image, name, hashtag, like button)
+│   ├── RecipeDetails.tsx   # Detail page — fetches by :recipeId, supports delete
+│   ├── RecipeInstructions.tsx # Renders instructions list
+│   ├── AddRecipe.tsx       # Form to create a recipe + upload an image
+│   ├── NavBar.tsx          # Shared header
+│   ├── Search.tsx          # Search input (client-side filter)
+│   ├── supabaseClient.ts   # Supabase client (reads env vars)
+│   ├── types.ts            # Recipe / Difficulty types; DIFFICULTY_OPTIONS
+│   ├── placeholder.ts      # PLACEHOLDER_IMAGE constant
+│   ├── hooks/              # Custom hooks (e.g. useStringList)
+│   ├── images/             # Static image assets
+│   ├── index.css           # Tailwind import + @theme color tokens
+│   └── vite-env.d.ts       # Vite client types
 └── package.json
 ```
 
 ## Key Architecture Decisions
 
-- **Single-page app** — BrowserRouter with two routes: `/` (all recipes) and `/recipes/:recipeId` (detail).
-- **React Router v6** — uses `<Routes>`/`<Route element={...}>` syntax; `exact` prop removed (v6 default).
-- **React 18** — uses `createRoot` API.
-- **Data** — Hardcoded in `src/recipeData.js`. Each recipe: `{ id, name, src (image), hashtag }`.
-- **No backend** — All data is local; comments in RecipeDetails.jsx note future API integration.
-- **Like counter** — Local `useState` in RecipeCard (resets on page reload).
-- **JSX files use `.jsx` extension** — Vite 6 / Rollup require this; do not use `.js` for files containing JSX.
+- **Single-page app** — BrowserRouter with three routes: `/` (list), `/recipes/new` (add form), `/recipes/:recipeId` (detail).
+- **React Router v6** — uses `<Routes>`/`<Route element={...}>` syntax.
+- **React 18** — uses `createRoot` API; `react-jsx` transform is on, so components do NOT import React (only `index.tsx` does, for `StrictMode`).
+- **All source uses `.tsx`/`.ts`** — Vite 6 / Rollup require this for JSX and TS. Do not use `.js` / `.jsx`.
+- **Tailwind v4** — theme tokens live in `src/index.css` under `@theme` and are referenced as Tailwind utilities (`bg-primary`, `text-muted`, etc.). Never hardcode color hex values in components.
+- **Supabase as backend** — `recipes` table holds recipe rows; `recipe-images` storage bucket holds uploaded images. Table/bucket names are inlined at call sites (no constants file).
+- **Like counter** — Local `useState` in `RecipeCard`; does not persist across reloads (see open issue #19).
+
+## Testing / Quality
+
+- `App.test.tsx` and `setupTests.ts` exist but there is **no test runner wired up**. They are excluded from `tsconfig.json`.
+- `npm run typecheck` is the primary correctness check today.
 
 ## What's Not Yet Implemented
 
-- Search functionality (form is rendered but unwired)
-- Real ingredients & instructions (RecipeInstructions.jsx is a layout placeholder)
-- Recipe detail cooking info is hardcoded (prep time, portions, difficulty)
-- No API integration
+See open GitHub issues for the full picture. At a high level:
+- Edit recipe (#17)
+- Error handling for Supabase queries (#15)
+- Persisted "was this worth repeating?" signal (reframing of #19)
+- Original source URL field on recipes (new)
+- Authentication (#23 — later scope, needed for sharing)
 
 ## Color Palette
 
-| Variable | Value |
-|----------|-------|
-| Primary | `#4a717e` (teal) |
-| Accent | `#e7712b` (orange) |
-| Muted | `#909090` |
-| Background | `#f6f6f6` |
+Defined as CSS custom properties in `src/index.css` under `@theme`. Use Tailwind utility names (`bg-primary`, `text-accent`, etc.), not raw hex values.
+
+| Token | Value | Purpose |
+|-------|-------|---------|
+| `--color-primary` | `#4a717e` | Primary teal (headings, nav) |
+| `--color-accent` | `#e7712b` | Accent orange (CTAs) |
+| `--color-accent-dark` | `#cf5f1e` | Hover state for accent |
+| `--color-muted` | `#909090` | Secondary text |
+| `--color-background` | `#f6f6f6` | Page background |
+| `--color-border` | `#dfdfdf` | Borders / dividers |
+| `--color-error` | `#c0392b` | Error states |
+| `--color-text` | `#2d2d2d` | Default body text |

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,47 @@
+# Recipe App — Vision
+
+## The problem
+Deciding what to cook is exhausting. Couples end up in a loop: the same few meals, or endless scrolling through ad-bloated recipe sites, or half-lost recipes scattered across Notes, screenshots, and WhatsApp. Original recipes disappear when blogs shut down. Modifications you made last time are forgotten by next time.
+
+## Who it's for
+Couples and small households who already cook, have found recipes they love, and want:
+- Their own curated cookbook of recipes they've *already approved*
+- Fast, distraction-free access to those recipes
+- A place that survives the original source being deleted
+- A way to capture and remember their own modifications
+
+**Primary users:** me and my husband. **If it ever grows:** other couples with the same decision-fatigue pain. Not generic "home cooks."
+
+## What it is
+A personal, curated digital cookbook optimized for two modes:
+
+1. **Decision support** — "what should we cook this week / tonight?" (desk or couch, browsing and planning)
+2. **Kitchen companion** — phone, wet hands, fast path from recipe to ingredients + steps
+
+Every recipe in the app has already passed our bar. Quality over quantity.
+
+## Design principles
+- **Low cognitive load.** Clean, uncluttered, minimal visual noise. Short paths to what matters. No decorative fluff.
+- **Instructions visible fast.** On the detail page, ingredients and steps are reachable without hunting past fluff.
+- **Modifications are first-class.** The app remembers *how we make it*, not just the original.
+- **Sacred data.** Once a recipe is in, it's ours. No reliance on external links staying alive.
+- **Source traceable.** Keep the original URL for credit/context, but never depend on it.
+
+## Anti-goals
+- **Ads, SEO content, life stories before the recipe.** Clean, fast access is non-negotiable. This is the thing that broke existing recipe sites for us, and we do not reintroduce it.
+
+## Out of initial scope (but aligned)
+Things we genuinely care about but aren't building now. Calling them out so the MVP doesn't accidentally close doors.
+
+- **Nutrition tracking** (calories, macros — per recipe, maybe per meal). We're a nutrition-focused household. *Design implication:* recipe schema should leave room for nutrition fields later.
+- **Shopping-list extraction.** Today we keep a running shopping note. Natural progression: (a) mark missing ingredients on a recipe, (b) export to a shopping note, (c) integrate with a supermarket (e.g., Albert Heijn). *Design implication:* the current `ingredients: string[]` field is flat — a real shopping list needs quantity / unit / item as separate fields to deduplicate and aggregate across recipes.
+- **Sharing with friends and family.** Share a recipe with a friend; import from a family member's cookbook for inspiration. *Design implication:* recipes will eventually need an owner (household account); authentication becomes a prerequisite for this direction.
+
+## Scope & monetization stance
+Primary scope is a working app for one household. If it becomes something others want, great — but architectural decisions should not optimize for that now. The one rule: **don't close doors.** Don't hardcode assumptions that would be painful to unwind if a second household ever used it.
+
+## Learning goals (meta — not product requirements)
+This project is also a vehicle for skill growth. Factor these in when picking what to work on:
+- **Backend.** Owner has mostly frontend experience; backend learning is prioritized.
+- **AI-assisted development.** Improving collaboration with Claude Code is an explicit goal.
+- **AI features in the app** are welcome when they genuinely help. Obvious candidate: *paste a URL, extract the recipe into our format.*


### PR DESCRIPTION
## Summary
- `VISION.md` (new) — target users, problem, design principles, anti-goals, later-scope features. Anchors future scope decisions so new issues/PRs can be checked against it.
- `CLAUDE.md` — refreshed to match the current stack (TypeScript, Tailwind v4, Supabase). Previous version still referenced Bootstrap, `.jsx`, hardcoded data. Adds a pointer to VISION.md at the top.

Follow-up work (new issues): #38–#42. Backlog has been triaged against the vision — see #19, #22, #23, #21 comments.

## Test plan
- [x] Read both docs in GitHub's rendering; flag anything that sounds off before merging