### PR TITLE
Ignore .claude/ and remove outdated design mockup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# local Claude Code project settings
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` — local Claude Code project settings, no need to share (solo project).
- Delete `design/recipe-detail.excalidraw` — mockup is no longer up to date.

## Test plan
- [ ] `git status` on this branch is clean (no stray untracked files)